### PR TITLE
Sd 447 - Special handling for symlinks

### DIFF
--- a/core/src/main/gov/nara/nwts/ftapp/FTDriver.java
+++ b/core/src/main/gov/nara/nwts/ftapp/FTDriver.java
@@ -51,6 +51,9 @@ public class FTDriver {
 	public String saveFile;
 	public File lastSavedFile;
 	public boolean overwrite = true;
+	public boolean followLinks() {
+		return false;
+	}
 	
 	public FileTestFilter myfilter;
 	public ResultFilter myresfilter;

--- a/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
+++ b/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
@@ -70,6 +70,9 @@ public class FileTraversal {
 			
 		}
 		for(int i=0; i<files.length; i++) {
+			if (Files.isSymbolicLink(files[i].toPath()) && !driver.followLinks()) {
+				continue;
+			}
 			if (files[i].isDirectory()) {
 				if (isCancelled()) return false; 
 				if (getNumProcessed() >= max) {
@@ -83,9 +86,7 @@ public class FileTraversal {
 					    test = p.matcher(files[i].getAbsolutePath()).matches();
 					}
 					if (test) {
-						if (!Files.isSymbolicLink(files[i].toPath()) || driver.followLinks()) {
-							checkDirFile(files[i], fileTest);
-						}
+						checkDirFile(files[i], fileTest);
 					}
 				}
 				increment();

--- a/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
+++ b/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
@@ -2,6 +2,7 @@ package gov.nara.nwts.ftapp;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.nio.file.Files;
 import java.util.regex.Pattern;
 
 
@@ -87,7 +88,11 @@ public class FileTraversal {
 			} else {
 				if (isCancelled()) return false; 
 				File thefile = files[i];
-				checkFile(thefile, fileTest);
+				
+				if (!Files.isSymbolicLink(thefile.toPath()) || driver.followLinks()) {
+					checkFile(thefile, fileTest);
+				}
+
 				fileTest.progress(getNumProcessed());
 				numProcessed++;
 				if (getNumProcessed() >= max) {

--- a/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
+++ b/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
@@ -63,7 +63,9 @@ public class FileTraversal {
 			    test = p.matcher(f.getAbsolutePath()).matches();
 			}
 			if (test) {
-				checkDirFile(f, fileTest);
+				if (!Files.isSymbolicLink(f.toPath()) || driver.followLinks()) {
+					checkDirFile(f, fileTest);
+				}
 			}
 			
 		}
@@ -81,7 +83,9 @@ public class FileTraversal {
 					    test = p.matcher(files[i].getAbsolutePath()).matches();
 					}
 					if (test) {
-						checkDirFile(files[i], fileTest);
+						if (!Files.isSymbolicLink(files[i].toPath()) || driver.followLinks()) {
+							checkDirFile(files[i], fileTest);
+						}
 					}
 				}
 				increment();

--- a/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
+++ b/core/src/main/gov/nara/nwts/ftapp/FileTraversal.java
@@ -3,6 +3,8 @@ package gov.nara.nwts.ftapp;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 
 
@@ -22,6 +24,8 @@ public class FileTraversal {
 	protected FTDriver driver;
 	protected FilenameFilter fileFilter;
 	protected FilenameFilter dirnameFilter;
+	
+	protected HashSet<Path> alreadyVisited = new HashSet<Path>();
 	
 	public FileTest fileTest;
 	protected int max;
@@ -53,6 +57,7 @@ public class FileTraversal {
 		System.err.println("Stopping: " +max + " items found.");
 	}
 	public boolean traverse(File f, FileTest fileTest, int max) {
+		alreadyVisited = new HashSet<Path>();
 		if (f==null) return false;
 		File[] files = f.listFiles(fileFilter);
 		if (files == null) return true;
@@ -72,6 +77,14 @@ public class FileTraversal {
 		for(int i=0; i<files.length; i++) {
 			if (Files.isSymbolicLink(files[i].toPath()) && !driver.followLinks()) {
 				continue;
+			}
+			
+			if (driver.followLinks()) {
+				Path path = files[i].toPath().toAbsolutePath();
+				if (alreadyVisited.contains(path)) {
+					continue;
+				}
+				alreadyVisited.add(path);
 			}
 			if (files[i].isDirectory()) {
 				if (isCancelled()) return false; 

--- a/core/src/main/gov/nara/nwts/ftapp/gui/CriteriaPanel.java
+++ b/core/src/main/gov/nara/nwts/ftapp/gui/CriteriaPanel.java
@@ -43,6 +43,7 @@ class CriteriaPanel extends MyPanel {
 	JComboBox<FileTest> actions;
 	JComboBox<Integer> limit;
 	JCheckBox ignorePeriods;
+	JCheckBox followLinks;
 	JCheckBox fcb;
 	JTextArea description;
 	JPanel propFilterPanel;
@@ -104,6 +105,10 @@ class CriteriaPanel extends MyPanel {
 		ignorePeriods.setSelected(true);
 		ignorePeriods.setText("Assume directory names do not contain periods (faster)");
 		adv1.add(ignorePeriods);
+		followLinks = new JCheckBox();
+		followLinks.setSelected(false);
+		followLinks.setText("Follow Links");
+		adv1.add(followLinks);
 
 		JPanel adv2 = new JPanel();
 		adv2.setBorder(BorderFactory.createTitledBorder("Auto-save Output directory"));

--- a/core/src/main/gov/nara/nwts/ftapp/gui/DirectoryTable.java
+++ b/core/src/main/gov/nara/nwts/ftapp/gui/DirectoryTable.java
@@ -199,6 +199,10 @@ public class DirectoryTable extends FTDriver {
 		
 	}
 
+	public boolean followLinks() {
+		return this.criteriaPanel.followLinks.isSelected();
+	}
+	
 	/**
 	 * Reset the filter and property tabs based on the selected FileTest.
 	 */


### PR DESCRIPTION
Allow user to turn on/off symlink traversal.

This is a quick solution.  More logic will be added to prevent re-visiting the same file/dir when traversing a link.