### PR TITLE
APTrust - Enhance Bag Number/Bag Total Validation

### DIFF
--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/AIPToAPT.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/AIPToAPT.java
@@ -18,7 +18,7 @@ import java.nio.file.Path;
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper.Access;
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper.BagStatsItems;
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper.STAT;
-import edu.georgetown.library.fileAnalyzer.util.FABagHelper.IncompleteSettingsExcpetion;
+import edu.georgetown.library.fileAnalyzer.util.IncompleteSettingsException;
 import edu.georgetown.library.fileAnalyzer.util.InvalidMetadataException;
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper;
 
@@ -120,7 +120,7 @@ abstract class AIPToAPT extends DefaultFileTest {
 			stat.setVal(BagStatsItems.Stat, STAT.ERROR);
 			stat.setVal(BagStatsItems.Message, e.getLocalizedMessage());
 			e.printStackTrace();
-		} catch (IncompleteSettingsExcpetion e) {
+		} catch (IncompleteSettingsException e) {
 			stat.setVal(BagStatsItems.Stat, STAT.INVALID);
 			stat.setVal(BagStatsItems.Message, e.getLocalizedMessage());
 			e.printStackTrace();

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/CreateAPTrustBag.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/CreateAPTrustBag.java
@@ -7,6 +7,7 @@ import gov.nara.nwts.ftapp.filetest.DefaultFileTest;
 import gov.nara.nwts.ftapp.ftprop.FTPropEnum;
 import gov.nara.nwts.ftapp.ftprop.FTPropInt;
 import gov.nara.nwts.ftapp.ftprop.FTPropString;
+import gov.nara.nwts.ftapp.ftprop.InitializationStatus;
 import gov.nara.nwts.ftapp.stats.Stats;
 import gov.nara.nwts.ftapp.stats.StatsGenerator;
 import gov.nara.nwts.ftapp.stats.StatsItem;
@@ -17,7 +18,7 @@ import java.io.File;
 import java.io.IOException;
 
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper.Access;
-import edu.georgetown.library.fileAnalyzer.util.FABagHelper.IncompleteSettingsExcpetion;
+import edu.georgetown.library.fileAnalyzer.util.IncompleteSettingsException;
 import edu.georgetown.library.fileAnalyzer.util.FABagHelper;
 import edu.georgetown.library.fileAnalyzer.util.APTrustHelper;
 
@@ -99,7 +100,20 @@ class CreateAPTrustBag extends DefaultFileTest {
         ftprops.add(pAccess);
 	}
 
-	public String toString() {
+    @Override public InitializationStatus init() {
+        InitializationStatus istat = super.init();
+        try {
+            FABagHelper.validateBagCount(
+                this.getProperty(APTrustHelper.P_BAGCOUNT).toString(), 
+                this.getProperty(APTrustHelper.P_BAGTOTAL).toString() 
+            );                    
+        } catch(IncompleteSettingsException e) {
+            istat.addFailMessage(e.getMessage());                    
+        }
+        return istat;
+    }
+
+    public String toString() {
 		return "Create APTrust Bag";
 	}
 	public String getKey(File f) {
@@ -135,7 +149,7 @@ class CreateAPTrustBag extends DefaultFileTest {
     			}			
     		}
     		
-    		aptHelper.createBagFile();
+    		aptHelper.createBagFile();  
     		aptHelper.generateBagInfoFiles();
     		aptHelper.writeBagFile();
     		
@@ -145,7 +159,7 @@ class CreateAPTrustBag extends DefaultFileTest {
 		} catch (IOException e) {
 			s.setVal(BagStatsItems.Stat, FABagHelper.STAT.ERROR);
 			s.setVal(BagStatsItems.Message, e.getMessage());
-		} catch (IncompleteSettingsExcpetion e) {
+		} catch (IncompleteSettingsException e) {
 			s.setVal(BagStatsItems.Stat, FABagHelper.STAT.ERROR);
 			s.setVal(BagStatsItems.Message, e.getMessage());
 		}

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
@@ -88,12 +88,14 @@ class VerifyAPTrustBagTar extends VerifyBagTar {
     	}
     	
         int total = -1;
+        int count = -1;
     	String scount = s.getStringVal(BagStatsItems.BagCount, "");    	
         String stotal = s.getStringVal(BagStatsItems.BagTotal, "");
         
         try {
             FABagHelper.validateBagCount(scount, stotal);
             total = Integer.parseInt(stotal);
+            count = Integer.parseInt(scount);
         } catch (IncompleteSettingsException e) {
             s.setVal(BagStatsItems.Stat, STAT.INVALID);
             s.appendVal(BagStatsItems.Message, "Invalid Bag Count. " + e.getMessage());             
@@ -101,10 +103,14 @@ class VerifyAPTrustBagTar extends VerifyBagTar {
     	
     	Matcher m = pAPTMulti.matcher(fname);
     	if (m.matches()) {
-    	    if (!scount.equals(m.group(1))) {
+    	    if (!String.format("%03d", count).equals(m.group(1))) {
         	    s.setVal(BagStatsItems.Stat, STAT.INVALID);
-        	    s.appendVal(BagStatsItems.Message, String.format("Bag count %s mismatch in bag file name %s. ", scount, m.group(1)));     
+        	    s.appendVal(BagStatsItems.Message, String.format("Bag number (%s) mismatch in bag file name %s. ", scount, m.group(1)));     
     	    }
+            if (!String.format("%03d", total).equals(m.group(2))) {
+                s.setVal(BagStatsItems.Stat, STAT.INVALID);
+                s.appendVal(BagStatsItems.Message, String.format("Bag total (%s) mismatch in bag file name %s. ", scount, m.group(2)));     
+            }
         } else if (total == 1) {
             m = pAPT.matcher(fname);                
             if (!m.matches()) {

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
@@ -9,6 +9,8 @@ import java.io.InputStreamReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import edu.georgetown.library.fileAnalyzer.util.FABagHelper;
+import edu.georgetown.library.fileAnalyzer.util.IncompleteSettingsException;
 import gov.loc.repository.bagit.Bag;
 import gov.loc.repository.bagit.BagFile;
 import gov.nara.nwts.ftapp.FTDriver;
@@ -28,7 +30,8 @@ class VerifyAPTrustBagTar extends VerifyBagTar {
 	public static final String APT_TITLE = "APT Title";
 	public static final String APT_ACCESS = "APT Access";
 	
-    static Pattern pAPT = Pattern.compile("^.+\\..+\\.b(\\d{3,3})\\.of(\\d{3,3})\\.tar$");
+    static Pattern pAPTMulti = Pattern.compile("^.+\\..+\\.b(\\d{3,3})\\.of(\\d{3,3})\\.tar$");
+    static Pattern pAPT = Pattern.compile("^.+\\..+\\.tar$");
     static Pattern pTitle = Pattern.compile("^Title:\\s*(.*)$");
     static Pattern pAccess = Pattern.compile("^Access:\\s*(Consortia|Restricted|Institution)\\s*$");
     
@@ -84,31 +87,33 @@ class VerifyAPTrustBagTar extends VerifyBagTar {
     	    s.appendVal(BagStatsItems.Message, "Source Org should not be null. "); 
     	}
     	
-    	int count = -1;
+        int total = -1;
     	String scount = s.getStringVal(BagStatsItems.BagCount, "");    	
-    	if (scount.isEmpty()) {
-    	    s.setVal(BagStatsItems.Stat, STAT.INVALID);
-    	    s.appendVal(BagStatsItems.Message, "Bag Count should not be null. "); 
-    	} else {
-    		try {
-				count = Integer.parseInt(scount);
-				scount = String.format("%03d", count);
-			} catch (NumberFormatException e) {
-				scount = "";
-	    	    s.setVal(BagStatsItems.Stat, STAT.INVALID);
-	    	    s.appendVal(BagStatsItems.Message, "Bag Count should be numeric. "); 
-			}
-    	}
+        String stotal = s.getStringVal(BagStatsItems.BagTotal, "");
+        
+        try {
+            FABagHelper.validateBagCount(scount, stotal);
+            total = Integer.parseInt(stotal);
+        } catch (IncompleteSettingsException e) {
+            s.setVal(BagStatsItems.Stat, STAT.INVALID);
+            s.appendVal(BagStatsItems.Message, "Invalid Bag Count. " + e.getMessage());             
+        }
     	
-    	Matcher m = pAPT.matcher(fname);
+    	Matcher m = pAPTMulti.matcher(fname);
     	if (m.matches()) {
     	    if (!scount.equals(m.group(1))) {
         	    s.setVal(BagStatsItems.Stat, STAT.INVALID);
         	    s.appendVal(BagStatsItems.Message, String.format("Bag count %s mismatch in bag file name %s. ", scount, m.group(1)));     
     	    }
+        } else if (total == 1) {
+            m = pAPT.matcher(fname);                
+            if (!m.matches()) {
+                s.setVal(BagStatsItems.Stat, STAT.INVALID);
+                s.appendVal(BagStatsItems.Message, "Single (Non-multipart) APTrust Bags must be named <instid>.<itemid>.tar.)");                     
+            }
     	} else {
     	    s.setVal(BagStatsItems.Stat, STAT.INVALID);
-    	    s.appendVal(BagStatsItems.Message, "APTrust Bags must be named <instid>.<itemid>.b<bag>.of<total>.tar where bag and total are 3 digits.)");     
+    	    s.appendVal(BagStatsItems.Message, "Multipart APTrust Bags must be named <instid>.<itemid>.b<bag>.of<total>.tar where bag and total are 3 digits.)");     
     	}
 
     	boolean hasTitle = false;

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyBag.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyBag.java
@@ -15,6 +15,9 @@ import gov.nara.nwts.ftapp.stats.StatsItemEnum;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Matcher;
+
+import edu.georgetown.library.fileAnalyzer.util.FABagHelper;
 
 /**
  * Extract all metadata fields from a TIF or JPG using categorized tag defintions.
@@ -38,6 +41,7 @@ class VerifyBag extends DefaultFileTest {
         BagSenderDesc(StatsItem.makeStringStatsItem("Sender Desc",150)),
         BagSenderId(StatsItem.makeStringStatsItem("Sender Id",150)),
         BagCount(StatsItem.makeStringStatsItem("Bag Count",150)),
+        BagTotal(StatsItem.makeStringStatsItem("Bag Total",150)),
         Message(StatsItem.makeStringStatsItem("Message",400)),
         ;
         StatsItem si;
@@ -97,7 +101,17 @@ class VerifyBag extends DefaultFileTest {
 				    s.setVal(BagStatsItems.BagSourceOrg, bit.getSourceOrganization());
 				    s.setVal(BagStatsItems.BagSenderDesc, bit.getInternalSenderDescription());
 				    s.setVal(BagStatsItems.BagSenderId, bit.getInternalSenderIdentifier());
-				    s.setVal(BagStatsItems.BagCount, bit.getBagCount());
+				    
+				    String countstr = bit.getBagCount() == null ? "" : bit.getBagCount().trim();
+				    
+				    Matcher m = FABagHelper.pBagCountStr.matcher(countstr); 
+				    if (m.matches()) {
+	                    s.setVal(BagStatsItems.BagCount, m.group(1));
+                        s.setVal(BagStatsItems.BagTotal, m.group(2));
+				    } else {				        
+                        s.setVal(BagStatsItems.BagCount, countstr);
+                        s.setVal(BagStatsItems.BagTotal, "");
+				    }
 				    
 				    validateBagMetadata(bag, fname, s);
 				} else {

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/APTrustHelper.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/APTrustHelper.java
@@ -99,7 +99,7 @@ public class APTrustHelper extends TarBagHelper {
 		this.title = title;
 	}    
    
-    @Override public void validateImpl(StringBuilder sb) throws IncompleteSettingsExcpetion {
+    @Override public void validateImpl(StringBuilder sb) throws IncompleteSettingsException {
     	if (instId == null) sb.append("Institution Id cannot be null. \n");
     	if (instId.isEmpty()) sb.append("Institution Id cannot be empty. \n");
     	if (itemUid == null) sb.append("Item Identifier cannot be null. \n");
@@ -117,7 +117,7 @@ public class APTrustHelper extends TarBagHelper {
     	if (title.isEmpty()) sb.append("Title cannot be empty. \n");
     }
         
-    @Override public void createBagFile() throws IncompleteSettingsExcpetion {
+    @Override public void createBagFile() throws IncompleteSettingsException {
     	validate();
 		String bagCount = String.format("%03d", ibagCount);
         String bagTotal = String.format("%03d", ibagTotal);
@@ -126,39 +126,41 @@ public class APTrustHelper extends TarBagHelper {
 		sb.append(instId);
 		sb.append(".");
         sb.append(itemUid);
-        sb.append(".b");
-        sb.append(bagCount);
-        sb.append(".of");
-        sb.append(bagTotal);
+        if ((ibagCount > 1) || (ibagTotal > 1)) {
+            sb.append(".b");
+            sb.append(bagCount);
+            sb.append(".of");
+            sb.append(bagTotal);            
+        }
 
-		newBag = new File(parent, sb.toString());
+		data.newBag = new File(data.parent, sb.toString());
     }
     
     public Bag getBag() {
-    	return bag;
+    	return data.bag;
     }
     
-    @Override public void generateBagInfoFiles() throws IOException, IncompleteSettingsExcpetion {
+    @Override public void generateBagInfoFiles() throws IOException, IncompleteSettingsException {
     	validate();
-    	if (newBag == null) throw new IncompleteSettingsExcpetion("Bag File must be created - call createBagFile()");
-        aptinfo = new File(parent, "aptrust-info.txt");
+    	if (data.newBag == null) throw new IncompleteSettingsException("Bag File must be created - call createBagFile()");
+        aptinfo = new File(data.parent, "aptrust-info.txt");
         BufferedWriter bw = new BufferedWriter(new FileWriter(aptinfo));
         bw.write(String.format("Title: %s%n", title));
         bw.write(String.format("Access: %s%n", access));
         bw.close();
-        bag.addFileAsTag(aptinfo);
+        data.bag.addFileAsTag(aptinfo);
 	    
         super.generateBagInfoFiles();
 
-	    BagInfoTxt bit = bag.getBagInfoTxt();
+	    BagInfoTxt bit = data.bag.getBagInfoTxt();
         bit.addSourceOrganization(srcOrg);
 	    bit.addInternalSenderDescription(intSendDesc);
 	    bit.addInternalSenderIdentifier(intSendId);
-	    bit.setBagCount(String.format("%03d", ibagCount));
+	    bit.setBagCount(String.format("%d of %d", ibagCount, ibagTotal));
     }
     
-    @Override public void writeBagFile() throws IOException, IncompleteSettingsExcpetion {
-    	if (aptinfo == null) throw new IncompleteSettingsExcpetion("Aptinfo File must be created - call generateBagInfoFiles()");
+    @Override public void writeBagFile() throws IOException, IncompleteSettingsException {
+    	if (aptinfo == null) throw new IncompleteSettingsException("Aptinfo File must be created - call generateBagInfoFiles()");
     	super.writeBagFile();
 	    aptinfo.delete();
     }

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/FABagHelper.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/FABagHelper.java
@@ -2,9 +2,11 @@ package edu.georgetown.library.fileAnalyzer.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import gov.loc.repository.bagit.Bag;
 import gov.loc.repository.bagit.BagFactory;
+import gov.loc.repository.bagit.BagInfoTxt;
 import gov.loc.repository.bagit.transformer.impl.DefaultCompleter;
 import gov.loc.repository.bagit.writer.Writer;
 import gov.loc.repository.bagit.writer.impl.FileSystemWriter;
@@ -21,56 +23,46 @@ public class FABagHelper {
 	public static final String P_SRCORG = "source-org";
     public static final String P_BAGTOTAL = "bag-total";
     public static final String P_BAGCOUNT = "bag-count";
+    public static final String P_BAGCOUNTSTR = "bag-count-str";
     public static final String P_INTSENDDESC = "internal-sender-desc";
     public static final String P_INTSENDID = "internal-sender-id";
     public static final String P_TITLE = "title";
     public static final String P_ACCESS = "access";
 
-    public class IncompleteSettingsExcpetion extends Exception {
-		private static final long serialVersionUID = 1L;
-
-		public IncompleteSettingsExcpetion(String message) {
-    		super(message);
-    	}
-    };
-    
-    File parent;
-    File source;
-    File newBag;
-    Bag bag;
-    BagFactory bf;
+    FABagHelperData data = new FABagHelperData();
+    public static Pattern pBagCountStr = Pattern.compile("^(\\d+) of (\\d+|\\?)$");
     
     public FABagHelper(File source) {
-    	this.source = source;
-    	this.parent = source.getParentFile();
-    	bf = new BagFactory();
-    	bag = bf.createBag();
+    	this.data.source = source;
+    	this.data.parent = source.getParentFile();
+    	data.bf = new BagFactory();
+    	data.bag = data.bf.createBag();
     }
     
-    public void validate() throws IncompleteSettingsExcpetion {
+    public void validate() throws IncompleteSettingsException {
     	StringBuilder sb = new StringBuilder();
     	validateImpl(sb);
     	if (sb.length() > 0) {
-    		throw new IncompleteSettingsExcpetion(sb.toString());
+    		throw new IncompleteSettingsException(sb.toString());
     	}
     }
-    public void validateImpl(StringBuilder sb) throws IncompleteSettingsExcpetion {
+    public void validateImpl(StringBuilder sb) throws IncompleteSettingsException {
     }
         
-    public void createBagFile() throws IncompleteSettingsExcpetion {
+    public void createBagFile() throws IncompleteSettingsException {
     	validate();
-		newBag = new File(parent, source.getName() + "_bag");
+		data.newBag = new File(data.parent, data.source.getName() + "_bag");
     }
     
     public Bag getBag() {
-    	return bag;
+    	return data.bag;
     }
     
-    public void generateBagInfoFiles() throws IOException, IncompleteSettingsExcpetion {
+    public void generateBagInfoFiles() throws IOException, IncompleteSettingsException {
     	validate();
-    	if (newBag == null) throw new IncompleteSettingsExcpetion("Bag File must be created - call createBagFile()");
+    	if (data.newBag == null) throw new IncompleteSettingsException("Bag File must be created - call createBagFile()");
 	    
-	    DefaultCompleter comp = new DefaultCompleter(bf);
+	    DefaultCompleter comp = new DefaultCompleter(data.bf);
 		
 		comp.setGenerateBagInfoTxt(true);
 		comp.setUpdateBaggingDate(true);
@@ -78,20 +70,54 @@ public class FABagHelper {
 		comp.setUpdatePayloadOxum(true);
 		comp.setGenerateTagManifest(false);
 		
-		bag = comp.complete(bag);
+		data.bag = comp.complete(data.bag);
     }
     
-    public void writeBagFile() throws IOException, IncompleteSettingsExcpetion {
+    public void writeBagFile() throws IOException, IncompleteSettingsException {
     	validate();
-    	if (newBag == null) throw new IncompleteSettingsExcpetion("Bag File must be created - call createBagFile()");
-	    Writer writer = new FileSystemWriter(bf); 
-	    bag.write(writer, newBag);
-	    bag.close();
+    	if (data.newBag == null) throw new IncompleteSettingsException("Bag File must be created - call createBagFile()");
+	    Writer writer = new FileSystemWriter(data.bf); 
+	    data.bag.write(writer, data.newBag);
+	    data.bag.close();
     }
     
-    public String getFinalBagName() throws IncompleteSettingsExcpetion {
+    public String getFinalBagName() throws IncompleteSettingsException {
     	validate();
-    	if (newBag == null) throw new IncompleteSettingsExcpetion("Bag File must be created - call createBagFile() and writeBagFile()");
-    	return newBag.getName();
+    	if (data.newBag == null) throw new IncompleteSettingsException("Bag File must be created - call createBagFile() and writeBagFile()");
+    	return data.newBag.getName();
+    }
+
+    public void setBagCountStr(String countStr) throws IncompleteSettingsException {
+        BagInfoTxt bit = data.bag.getBagInfoTxt();
+        if (bit == null) {
+            throw new IncompleteSettingsException("Bag info file must be generated before the count can be set");
+        }
+        bit.setBagCount(countStr);
+    }
+    
+    public static void validateBagCount(String bagNum, String bagTot) throws IncompleteSettingsException {
+        int ibagNum = 0;
+        try {
+            ibagNum = Integer.parseInt(bagNum);            
+        } catch(NumberFormatException e) {
+            throw new IncompleteSettingsException(String.format("Bag Number (%s) must be numeric", bagNum));
+        }
+        if (ibagNum < 1) {
+            throw new IncompleteSettingsException(String.format("Bag Number (%d) must be 1 or larger", ibagNum));
+        }
+        if (!bagTot.equals("?")) {
+            try {
+                int ibagTot = Integer.parseInt(bagTot);
+                if (ibagTot < 1) {
+                    throw new IncompleteSettingsException(String.format("Bag Total (%d) must be 1 or larger", ibagTot));
+                }
+                if (ibagNum > ibagTot) {                        
+                    throw new IncompleteSettingsException(String.format("Bag Num (%d) cannot be larger than Bag Total(%d)", ibagNum, ibagTot));            
+                }                
+            } catch(NumberFormatException e) {
+                throw new IncompleteSettingsException(String.format("Bag Total (%s) must be '?' or numeric", bagTot));
+            }
+        }
+
     }
 }

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/FABagHelperData.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/FABagHelperData.java
@@ -1,0 +1,17 @@
+package edu.georgetown.library.fileAnalyzer.util;
+
+import java.io.File;
+
+import gov.loc.repository.bagit.Bag;
+import gov.loc.repository.bagit.BagFactory;
+
+public class FABagHelperData {
+    public File parent;
+    public File source;
+    public File newBag;
+    public Bag bag;
+    public BagFactory bf;
+
+    public FABagHelperData() {
+    }
+}

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/IncompleteSettingsException.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/IncompleteSettingsException.java
@@ -1,0 +1,9 @@
+package edu.georgetown.library.fileAnalyzer.util;
+
+public class IncompleteSettingsException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public IncompleteSettingsException(String message) {
+        super(message);
+    }
+};

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarBagHelper.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarBagHelper.java
@@ -11,10 +11,10 @@ public class TarBagHelper extends FABagHelper {
     	super(source);
     }
     
-    @Override public void writeBagFile() throws IOException, IncompleteSettingsExcpetion {
+    @Override public void writeBagFile() throws IOException, IncompleteSettingsException {
     	super.writeBagFile();
 
-    	newBag = TarUtil.tarFolderAndDeleteFolder(newBag);
+    	data.newBag = TarUtil.tarFolderAndDeleteFolder(data.newBag);
     }
     
 }

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarUtil.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarUtil.java
@@ -17,6 +17,7 @@ public class TarUtil {
 	public static File tarFolder(File folder) throws FileNotFoundException, IOException {
 		File tarout = new File(folder.getParentFile(), folder.getName() + ".tar");
 		try(TarArchiveOutputStream tar = new TarArchiveOutputStream(new FileOutputStream(tarout))) {
+		    tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
 			TarArchiveEntry arch = new TarArchiveEntry(folder.getName() + "/");
 			tar.putArchiveEntry(arch);
 	        TarUtil.tarSubDirectory(folder.getName()+"/", folder, tar);			

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/ZipBagHelper.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/ZipBagHelper.java
@@ -11,18 +11,18 @@ public class ZipBagHelper extends FABagHelper {
     	super(source);
     }
     
-    @Override public void createBagFile() throws IncompleteSettingsExcpetion {
+    @Override public void createBagFile() throws IncompleteSettingsException {
     	validate();
-		newBag = new File(parent, source.getName() + "_bag.zip");
+		data.newBag = new File(data.parent, data.source.getName() + "_bag.zip");
     }
     
-    @Override public void writeBagFile() throws IOException, IncompleteSettingsExcpetion {
+    @Override public void writeBagFile() throws IOException, IncompleteSettingsException {
     	validate();
-    	if (newBag == null) throw new IncompleteSettingsExcpetion("Bag File must be created - call createBagFile()");
-	    ZipWriter writer = new ZipWriter(bf); 
-	    writer.setBagDir(source.getName());
-	    bag.write(writer, newBag);
-	    bag.close();
+    	if (data.newBag == null) throw new IncompleteSettingsException("Bag File must be created - call createBagFile()");
+	    ZipWriter writer = new ZipWriter(data.bf); 
+	    writer.setBagDir(data.source.getName());
+	    data.bag.write(writer, data.newBag);
+	    data.bag.close();
     }
     
 }


### PR DESCRIPTION
# APTrust: Do not include part numbers in filename when bag total is 1

![image](https://cloud.githubusercontent.com/assets/1111057/13189186/b4b46220-d70a-11e5-8dbf-1f364d1986f3.png)

![image](https://cloud.githubusercontent.com/assets/1111057/13189192/c3a81290-d70a-11e5-9da4-a6b89fd129b8.png)

## Part numbers are included when part total is > 1

![image](https://cloud.githubusercontent.com/assets/1111057/13189233/f64f28b4-d70a-11e5-96f5-389773e1aca4.png)

![image](https://cloud.githubusercontent.com/assets/1111057/13189237/fedd3f48-d70a-11e5-99ca-a45b93bc11dd.png)

## Validate bag number/bag total components of file name

![image](https://cloud.githubusercontent.com/assets/1111057/13189511/be873d3e-d70c-11e5-926f-5e0ea4045ad1.png)

# Create Bag (Generic)

![image](https://cloud.githubusercontent.com/assets/1111057/13189272/3e7b2e80-d70b-11e5-96b3-0f4a24655488.png)

![image](https://cloud.githubusercontent.com/assets/1111057/13189295/5fe4b834-d70b-11e5-83e7-ea33d5f885a7.png)

## Verify Bag

![image](https://cloud.githubusercontent.com/assets/1111057/13189317/8958d650-d70b-11e5-982e-2daaee543e73.png)
