### PR TITLE
Improve APT Bag validation

### DIFF
--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyAPTrustBagTar.java
@@ -33,7 +33,7 @@ class VerifyAPTrustBagTar extends VerifyBagTar {
     static Pattern pAPTMulti = Pattern.compile("^.+\\..+\\.b(\\d{3,3})\\.of(\\d{3,3})\\.tar$");
     static Pattern pAPT = Pattern.compile("^.+\\..+\\.tar$");
     static Pattern pTitle = Pattern.compile("^Title:\\s*(.*)$");
-    static Pattern pAccess = Pattern.compile("^Access:\\s*(Consortia|Restricted|Institution)\\s*$");
+    static Pattern pAccess = Pattern.compile("^Access:\\s*([Cc]onsortia|[Rr]estricted|[Ii]nstitution)\\s*$");
     
     public static StatsItemConfig details = StatsItemConfig.create(BagStatsItems.class);
 

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyBag.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/filetest/VerifyBag.java
@@ -96,24 +96,29 @@ class VerifyBag extends DefaultFileTest {
 				if (result.isSuccess()) {
 					BagInfoTxt bit = bag.getBagInfoTxt();
 					
-				    s.setVal(BagStatsItems.Stat, STAT.VALID);
-				    s.setVal(BagStatsItems.Message, "");
-				    s.setVal(BagStatsItems.BagSourceOrg, bit.getSourceOrganization());
-				    s.setVal(BagStatsItems.BagSenderDesc, bit.getInternalSenderDescription());
-				    s.setVal(BagStatsItems.BagSenderId, bit.getInternalSenderIdentifier());
+					if (bit == null) {
+                        s.setVal(BagStatsItems.Stat, STAT.INVALID);
+                        s.setVal(BagStatsItems.Message, "Bag Info Not Found. ");					    
+					} else {
+	                    s.setVal(BagStatsItems.Stat, STAT.VALID);
+	                    s.setVal(BagStatsItems.Message, "");
+	                    s.setVal(BagStatsItems.BagSourceOrg, bit.getSourceOrganization());
+	                    s.setVal(BagStatsItems.BagSenderDesc, bit.getInternalSenderDescription());
+	                    s.setVal(BagStatsItems.BagSenderId, bit.getInternalSenderIdentifier());
+	                    
+	                    String countstr = bit.getBagCount() == null ? "" : bit.getBagCount().trim();
+	                    
+	                    Matcher m = FABagHelper.pBagCountStr.matcher(countstr); 
+	                    if (m.matches()) {
+	                        s.setVal(BagStatsItems.BagCount, m.group(1));
+	                        s.setVal(BagStatsItems.BagTotal, m.group(2));
+	                    } else {                        
+	                        s.setVal(BagStatsItems.BagCount, countstr);
+	                        s.setVal(BagStatsItems.BagTotal, "");
+	                    }
+	                    validateBagMetadata(bag, fname, s);					    
+					}
 				    
-				    String countstr = bit.getBagCount() == null ? "" : bit.getBagCount().trim();
-				    
-				    Matcher m = FABagHelper.pBagCountStr.matcher(countstr); 
-				    if (m.matches()) {
-	                    s.setVal(BagStatsItems.BagCount, m.group(1));
-                        s.setVal(BagStatsItems.BagTotal, m.group(2));
-				    } else {				        
-                        s.setVal(BagStatsItems.BagCount, countstr);
-                        s.setVal(BagStatsItems.BagTotal, "");
-				    }
-				    
-				    validateBagMetadata(bag, fname, s);
 				} else {
 				    s.setVal(BagStatsItems.Stat, STAT.ERROR);
 				    for(String m: result.getMessages()) {
@@ -122,7 +127,8 @@ class VerifyBag extends DefaultFileTest {
 				}
 			} 
 		} catch (Exception e) {
-		    s.setVal(BagStatsItems.Message, e.getMessage());
+		    e.printStackTrace();
+		    s.setVal(BagStatsItems.Message, "Bag Error: " + e.getClass().getName() +" " + e.getMessage());
 		    s.setVal(BagStatsItems.Stat, STAT.NA);
 		}
         return s.getVal(BagStatsItems.Count);

--- a/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarUtil.java
+++ b/demo/src/main/edu/georgetown/library/fileAnalyzer/util/TarUtil.java
@@ -60,11 +60,15 @@ public class TarUtil {
 		Path temp = Files.createTempDirectory(f.getName());
 		temp.toFile().deleteOnExit();
 		TarArchiveInputStream taris = new TarArchiveInputStream(new FileInputStream(f));
+		
 		for(TarArchiveEntry entry = taris.getNextTarEntry(); entry != null; entry =  taris.getNextTarEntry()){
 			Path fentry = temp.resolve(entry.getName());
 			if (entry.isDirectory()) {
 		        Files.createDirectory(fentry);
 			} else {
+			    if (fentry.getParent() != null) {
+			        Files.createDirectories(fentry.getParent());
+			    }
 		        Files.copy(taris, fentry);
 			}
 			fentry.toFile().deleteOnExit();


### PR DESCRIPTION
1. bulletproof directory expansion on export
2. make Access options case insensitive
3. handle bag info string
